### PR TITLE
Use real %AppData% path to install. This change make working well on WindowsXP.

### DIFF
--- a/git-credential-winstore/Program.cs
+++ b/git-credential-winstore/Program.cs
@@ -15,12 +15,6 @@ namespace Git.Credential.WinStore
 {
     class Program
     {
-        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
-        public static extern int GetShortPathName(
-            [MarshalAs(UnmanagedType.LPTStr)] string path,
-            [MarshalAs(UnmanagedType.LPTStr)] StringBuilder shortPath,
-            int shortPathLength);
-
         private static Dictionary<string, Func<IDictionary<string, string>, IEnumerable<Tuple<string, string>>>> _commands = new Dictionary<string, Func<IDictionary<string, string>, IEnumerable<Tuple<string, string>>>>(StringComparer.OrdinalIgnoreCase)
         {
             { "get", GetCommand },
@@ -113,14 +107,7 @@ namespace Git.Credential.WinStore
             var dest = new FileInfo(Environment.ExpandEnvironmentVariables(@"%AppData%\GitCredStore\git-credential-winstore.exe"));
             File.Copy(Assembly.GetExecutingAssembly().Location, dest.FullName, true);
 
-            var path = dest.FullName;
-            var shortPath = new StringBuilder(255);
-            GetShortPathName(path, shortPath, shortPath.Capacity);
-            if (shortPath.Length > 0)
-            {
-                path = shortPath.ToString().ToLower();
-            }
-            Process.Start("git", string.Format("config --global credential.helper !\"{0}\"", path.Replace('\\', '/')));
+            Process.Start("git", string.Format("config --global credential.helper \"!'{0}'\"", dest.FullName));
         }
 
         static IEnumerable<Tuple<string, string>> GetCommand(IDictionary<string, string> args)


### PR DESCRIPTION
Hi.

Thanks to your awesome works. I'm using WindowsXP. So I don't have '~/AppPath'.
Below is a patch to make working well on WindowsXP.

Thanks.
