### PR TITLE
Failed Installation Recovery

### DIFF
--- a/git-credential-winstore/Program.cs
+++ b/git-credential-winstore/Program.cs
@@ -128,9 +128,16 @@ namespace Git.Credential.WinStore
             }
 
             var dest = new FileInfo(Environment.ExpandEnvironmentVariables(@"%AppData%\GitCredStore\git-credential-winstore.exe"));
-            File.Copy(Assembly.GetExecutingAssembly().Location, dest.FullName, true);
+            var destinationPath = dest.FullName;
 
-            Process.Start("git", string.Format("config --global credential.helper \"!'{0}'\"", dest.FullName));
+            if (File.Exists(destinationPath))
+            {
+                File.Delete(destinationPath);
+            }
+
+            File.Copy(Assembly.GetExecutingAssembly().Location, destinationPath, true);
+
+            Process.Start("git", string.Format("config --global credential.helper \"!'{0}'\"", destinationPath));
         }
 
         static IEnumerable<Tuple<string, string>> GetCommand(IDictionary<string, string> args)


### PR DESCRIPTION
Initially I launched the installer from Windows Explorer, and the installation failed because the git command wasn't in my path. I then tried to launch the installer from msysgit and this failed because the git-credential-winstore.exe already existed in %AppData%\Roaming\GitCredStore. 

I modified the Program.cs to see if the .exe exists before copying and if it does delete the current .exe and then copy again.
