### PR TITLE
Eliminate scoping of cred store entry

### DIFF
--- a/git-credential-winstore/Program.cs
+++ b/git-credential-winstore/Program.cs
@@ -388,7 +388,8 @@ namespace Git.Credential.WinStore
 
         private static string GetTargetName(Uri url)
         {
-            return "git:" + GetHost(url);
+            // not scoping url host to encourage sharing of credentials and minimal maintenance with other windows git clients
+            return GetHost(url);
         }
 
         private static string GetHost(Uri url)


### PR DESCRIPTION
_PUT ON HOLD_ - Andrew, I'm having conversations with a couple other folks so we should hold this pull request for a awhile.

By eliminating the scoping of the cred store entry (url prefixed with "git:") it allows and encourages other windows git clients to share the credentials and the management and maintenance that goes along with it. 
