### PR TITLE
Add support for paths containing any mixture of single quotes and spaces

### DIFF
--- a/git-credential-winstore/Program.cs
+++ b/git-credential-winstore/Program.cs
@@ -153,7 +153,7 @@ namespace Git.Credential.WinStore
             {
                 target.Create();
             }
-
+            
             var dest = new FileInfo(Environment.ExpandEnvironmentVariables(@"%AppData%\GitCredStore\git-credential-winstore.exe"));
             if (dest.Exists)
             {
@@ -161,7 +161,12 @@ namespace Git.Credential.WinStore
             }
             File.Copy(Assembly.GetExecutingAssembly().Location, dest.FullName, true);
 
-            Process.Start(pathToGit, string.Format("config --global credential.helper \"!'{0}'\"", dest.FullName));
+            // Git config command auto-escapes the escape char, so we end up with \\ in .gitconfig where we see \\ in the code below..
+            // First, switch to "/" instead of "\\" for path separator, then escape spaces and single-quotes...
+            var gitEscapedExePath = dest.FullName.Replace("\\", "/").Replace(" ", "\\ ").Replace("'", "\\'");
+            var gitCommand = string.Format("config --global credential.helper \"{0}\"", gitEscapedExePath);
+
+            Process.Start(pathToGit, gitCommand);
         }
 
         static IEnumerable<Tuple<string, string>> GetCommand(IDictionary<string, string> args)


### PR DESCRIPTION
I was trying to install this on a friend's computer yesterday, and had trouble because her surname is "O'Doherty", which is also in the path to her AppData folder. After 10 minutes I gave up and moved the exe to a path without any apostrophes, but it annoyed me that I couldn't write the .gifconfig correctly to use paths with apostrophes, nevermind the bash command to correctly update the config!

After another few hours of playing, I've finally solved it, so, I hope this is useful! It's my first contribution to an open source project.

Thanks for all your contributions and for starting the project,

Sam
